### PR TITLE
Add min-width of 320px to all pages

### DIFF
--- a/public/css/global.css
+++ b/public/css/global.css
@@ -4,6 +4,7 @@
 body {
     margin: 0;
     font-size: 15px;
+    min-width: 320px;
     color: #151948;
     background: #fbfbfb;
     font-family: 'Lato', sans-serif;


### PR DESCRIPTION
#2 Solves Issue #2 where the content starts to leak out of box after the width gets too small

320px is the width of an iPhone SE and the smallest width you can get on most iPads (I know I'm using Apple devices but the "Responsive Design Mode" setting on my Mac allows me to see that)